### PR TITLE
ci: migrate AWS credentials to GitHub Actions OIDC

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -14,6 +14,7 @@ permissions:
   contents: read
   packages: read
   deployments: write
+  id-token: write
 
 jobs:
   detect-changes:
@@ -33,6 +34,7 @@ jobs:
   iac-deploy:
     needs: detect-changes
     runs-on: ubuntu-latest
+    environment: production
     container:
         image: ghcr.io/${{ github.repository }}/cached-devcontainer:latest
     if: needs.detect-changes.outputs.iac-changed == 'true'
@@ -49,8 +51,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ${{ matrix.stack }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -14,6 +14,7 @@ on:
 permissions:
   contents: read
   packages: read
+  id-token: write
 
 jobs:
   # This job detects which parts of the repo have been changed, setting future jobs up for conditional behavior.
@@ -51,6 +52,7 @@ jobs:
   iac-diff:
     needs: detect-changes
     runs-on: ubuntu-latest
+    environment: validate
     container:
         image: ghcr.io/${{ github.repository }}/cached-devcontainer:latest
     if: needs.detect-changes.outputs.iac-changed == 'true'
@@ -66,8 +68,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ${{ matrix.stack }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
 
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

- Replaces `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` with short-lived OIDC role assumption
- IAM roles already provisioned in [thunderbird/platform-infrastructure#218](https://github.com/thunderbird/platform-infrastructure/pull/218)

Closes #7. Part of [thunderbird/platform-infrastructure#10](https://github.com/thunderbird/platform-infrastructure/issues/10).

## Changes

| File | Change |
|------|--------|
| `merge.yaml` | `environment: production`, `id-token: write`, `role-to-assume` |
| `validate.yaml` | `environment: validate`, `id-token: write`, `role-to-assume` |

GitHub Environments `production` and `validate` are already created with `AWS_ROLE_ARN` set to the provisioned role ARNs.

## Role policy scope

The `production` role has full CRUD on SecurityHub, GuardDuty, AWS Config, IAM, S3, SNS, and SecretsManager -- all scoped to `cloud-security-iac-*` resources. Replaces `IAMFullAccess + config:*` on the legacy CI key.

The `validate` role is read-only (describe/get/list) and also trusts `pull_request` sub claims so previews run on PRs without needing the `validate` environment.

## After this merges

- [ ] Verify `merge.yaml` runs successfully on next merge to main
- [ ] Delete `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` from repo secrets
- [ ] Delete legacy IAM user `cloud-security-iac-eu-central-1-ci-ci` in `thunderbird-legacy`

Generated with [Claude Code](https://claude.com/claude-code)
