### PR TITLE
ci: add workflow_dispatch to merge-and-deploy-global

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -23,7 +23,7 @@ jobs:
   detect-changes:
     runs-on: ubuntu-latest
     outputs:
-      iac-changed: ${{ steps.check.outputs.iac-changed }}
+      iac-changed: ${{ steps.check.outputs.pulumi }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -9,6 +9,9 @@ on:
   push:
     branches:
       - "main"
+  workflow_dispatch:
+    branches:
+      - "main"
 
 permissions:
   contents: read
@@ -37,7 +40,7 @@ jobs:
     environment: production
     container:
         image: ghcr.io/${{ github.repository }}/cached-devcontainer:latest
-    if: needs.detect-changes.outputs.iac-changed == 'true'
+    if: needs.detect-changes.outputs.iac-changed == 'true' || github.event_name == 'workflow_dispatch'
     strategy:
       matrix:
         stack: [us-east-1, us-east-2, us-west-1, us-west-2, eu-central-1]

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -21,7 +21,7 @@ jobs:
   detect-changes:
     runs-on: ubuntu-latest
     outputs:
-      iac-changed: ${{ steps.check.outputs.iac-changed }}
+      iac-changed: ${{ steps.check.outputs.pulumi }}
 
     steps:
       - uses: actions/checkout@v4

--- a/pulumi/__main__.py
+++ b/pulumi/__main__.py
@@ -74,4 +74,3 @@ sap = tb_pulumi.iam.StackAccessPolicies(
     f'{project.name_prefix}-sap',
     project=project,
 )
-

--- a/pulumi/__main__.py
+++ b/pulumi/__main__.py
@@ -74,3 +74,4 @@ sap = tb_pulumi.iam.StackAccessPolicies(
     f'{project.name_prefix}-sap',
     project=project,
 )
+


### PR DESCRIPTION
Closes #10.

## Summary

Three fixes in one PR:

1. **`workflow_dispatch`** on `merge-and-deploy-global` (constrained to `main`) — allows manually triggering a full deploy without a code change
2. **`paths-filter` bug fix** — the filter was named `pulumi` but both workflows read `steps.check.outputs.iac-changed` (always empty), causing `iac-deploy` and `iac-diff` to be permanently skipped on pulumi code changes. Fixed to `steps.check.outputs.pulumi`.
3. **`workflow_dispatch` bypass** — `iac-deploy` now runs unconditionally on manual dispatch regardless of paths-filter result

## Validation

Run [`24696785391`](https://github.com/thunderbird/cloud-security-iac/actions/runs/24696785391) confirms the paths-filter fix works and OIDC credentials are valid — all 5 `iac-diff` regions passed:

| Region | Result |
|--------|--------|
| us-east-1 | success |
| us-east-2 | success |
| us-west-1 | success |
| us-west-2 | success |
| eu-central-1 | success |

After merging, trigger **Actions → merge-and-deploy-global → Run workflow** on `main` to verify the `production` OIDC role works for `pulumi up` across all 5 regions.

Generated with [Claude Code](https://claude.com/claude-code)
