### PR TITLE
fix: remove RUNTIME_MONITORING and delete legacy CI IAM user

### DIFF
--- a/pulumi/config.eu-central-1.yaml
+++ b/pulumi/config.eu-central-1.yaml
@@ -9,17 +9,6 @@ resources:
         status: "ENABLED"
       - name: "EKS_AUDIT_LOGS"
         status: "DISABLED"
-      - name: "RUNTIME_MONITORING"
-        status: "ENABLED"
-        additional_configurations:
-          - {
-              'name': 'ECS_FARGATE_AGENT_MANAGEMENT',
-              'status': 'ENABLED',
-            }
-          - {
-              'name': 'EC2_AGENT_MANAGEMENT',
-              'status': 'ENABLED',
-            }
       # - name: "EKS_RUNTIME_MONITORING"
       #   status: "DISABLED"
       #   additional_configurations:
@@ -39,13 +28,3 @@ resources:
     aggregator_stack: True
     delivery_email: "services-dev@thunderbird.net"
 
-  tb:ci:AwsAutomationUser:
-    ci:
-      access_keys: {}
-      enable_legacy_access_key: True
-      # additional_policies:
-        # - arn:aws:iam::768512802988:policy/send-suite-prod-frontend-cache-invalidation
-      enable_ecr_image_push: false
-      enable_fargate_deployments: false
-      enable_full_s3_access: false
-      enable_s3_bucket_upload: false

--- a/pulumi/config.us-east-1.yaml
+++ b/pulumi/config.us-east-1.yaml
@@ -9,17 +9,6 @@ resources:
         status: "ENABLED"
       - name: "EKS_AUDIT_LOGS"
         status: "DISABLED"
-      - name: "RUNTIME_MONITORING"
-        status: "ENABLED"
-        additional_configurations:
-          - {
-              'name': 'ECS_FARGATE_AGENT_MANAGEMENT',
-              'status': 'ENABLED',
-            }
-          - {
-              'name': 'EC2_AGENT_MANAGEMENT',
-              'status': 'ENABLED',
-            }
       # - name: "EKS_RUNTIME_MONITORING"
       #   status: "DISABLED"
       #   additional_configurations:

--- a/pulumi/config.us-east-2.yaml
+++ b/pulumi/config.us-east-2.yaml
@@ -9,17 +9,6 @@ resources:
         status: "ENABLED"
       - name: "EKS_AUDIT_LOGS"
         status: "DISABLED"
-      - name: "RUNTIME_MONITORING"
-        status: "ENABLED"
-        additional_configurations:
-          - {
-              'name': 'ECS_FARGATE_AGENT_MANAGEMENT',
-              'status': 'ENABLED',
-            }
-          - {
-              'name': 'EC2_AGENT_MANAGEMENT',
-              'status': 'ENABLED',
-            }
       # - name: "EKS_RUNTIME_MONITORING"
       #   status: "DISABLED"
       #   additional_configurations:

--- a/pulumi/config.us-west-1.yaml
+++ b/pulumi/config.us-west-1.yaml
@@ -9,17 +9,6 @@ resources:
         status: "ENABLED"
       - name: "EKS_AUDIT_LOGS"
         status: "DISABLED"
-      - name: "RUNTIME_MONITORING"
-        status: "ENABLED"
-        additional_configurations:
-          - {
-              'name': 'ECS_FARGATE_AGENT_MANAGEMENT',
-              'status': 'ENABLED',
-            }
-          - {
-              'name': 'EC2_AGENT_MANAGEMENT',
-              'status': 'ENABLED',
-            }
       # - name: "EKS_RUNTIME_MONITORING"
       #   status: "DISABLED"
       #   additional_configurations:

--- a/pulumi/config.us-west-2.yaml
+++ b/pulumi/config.us-west-2.yaml
@@ -9,17 +9,6 @@ resources:
         status: "ENABLED"
       - name: "EKS_AUDIT_LOGS"
         status: "DISABLED"
-      - name: "RUNTIME_MONITORING"
-        status: "ENABLED"
-        additional_configurations:
-          - {
-              'name': 'ECS_FARGATE_AGENT_MANAGEMENT',
-              'status': 'ENABLED',
-            }
-          - {
-              'name': 'EC2_AGENT_MANAGEMENT',
-              'status': 'ENABLED',
-            }
       # - name: "EKS_RUNTIME_MONITORING"
       #   status: "DISABLED"
       #   additional_configurations:


### PR DESCRIPTION
Closes #12. Part of [thunderbird/platform-infrastructure#10](https://github.com/thunderbird/platform-infrastructure/issues/10).

## Summary

Two config-only changes that unblock `pulumi up` and complete the OIDC credential migration for `cloud-security-iac`.

### 1. Remove `RUNTIME_MONITORING` from all 5 region configs

`thunderbird-legacy` is a GuardDuty **member account**. The `RUNTIME_MONITORING` feature (and its `ECS_FARGATE_AGENT_MANAGEMENT` / `EC2_AGENT_MANAGEMENT` sub-configs) can only be managed from the delegated administrator — member accounts get `BadRequestException` when attempting to set it. The feature remains enabled at the org level; we're just removing Pulumi's attempt to manage it.

### 2. Remove `tb:ci:AwsAutomationUser` from `config.eu-central-1.yaml`

The GitHub Actions secrets `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` have already been deleted from this repo — the user `cloud-security-iac-eu-central-1-ci-ci` can no longer authenticate from CI. Running `pulumi up` will destroy the IAM user, its access keys, inline policies, and SecretsManager secret.

OIDC roles provisioned in [thunderbird/platform-infrastructure#218](https://github.com/thunderbird/platform-infrastructure/pull/218) are the replacement.

## After merging

Trigger **Actions → merge-and-deploy-global → Run workflow** on `main` to apply. Verify:
- All 5 region stacks complete with no errors
- `cloud-security-iac-eu-central-1-ci-ci` IAM user no longer exists in `thunderbird-legacy`

Generated with [Claude Code](https://claude.com/claude-code)
